### PR TITLE
distribute cppyythonizations on PyPI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,18 @@ on:
 
 jobs:
   test-cppyythonizations:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.on }}
     strategy:
       matrix:
         python: ["3.6", "3.7", "3.8", "3.9"]
+        on:
+          - ubuntu-20.04
+          - macos-11.0
         target:
           - check
         include:
           - python: 3.9
+            on: ubuntu-20.04
             target: check-valgrind
     steps:
       - uses: actions/checkout@v2
@@ -31,13 +35,19 @@ jobs:
       - name: make ${{ matrix.target }}
         shell: bash -l {0}
         run: |
+          echo "::group::bootstrap"
           ./bootstrap
+
+          echo "::group::configure"
           export CXXFLAGS="$CXXFLAGS -UNDEBUG"
-          ./configure --prefix="$PREFIX" --without-benchmark
+          ./configure
+
+          echo "::group::make"
           make
+
+          echo "::group::make ${{ matrix.target }}"
           make ${{ matrix.target }}
-      - name: show logs
-        run: grep "" /dev/null `find -name '*.log'` || true
+      - uses: flatsurf/actions/show-logs@main
         if: ${{ always() }}
   distcheck:
     runs-on: ubuntu-20.04
@@ -54,11 +64,15 @@ jobs:
       - name: make distcheck
         shell: bash -l {0}
         run: |
+          echo "::group::bootstrap"
           ./bootstrap
-          ./configure --prefix="$PREFIX"
+
+          echo "::group::configure"
+          ./configure
+
+          echo "::group::make distcheck"
           make distcheck
-      - name: show logs
-        run: grep "" /dev/null `find -name '*.log'` || true
+      - uses: flatsurf/actions/show-logs@main
         if: ${{ always() }}
 
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,4 @@ vgcore.*
 ### Log files
 *.log
 
-rever/
+/rever

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ reusable extensions such as Python pickling of C++ classes.
 
 ## Current Release Info
 
-We build and release this package with every push to the master branch. These releases are considered unstable and highly
-experimental. There are no stable releases yet.
+We release this package very frequently, typically with most pushes to the master branch.
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
@@ -22,6 +21,12 @@ You can install this package with conda. Download and install [Miniconda](https:
 conda config --add channels conda-forge
 conda create -n cppyy -c flatsurf cppyy cppyythonizations
 conda activate cppyy
+```
+
+## Install with pip
+
+```
+pip install cppyythonizations
 ```
 
 ## Build from the Source Code Repository
@@ -52,12 +57,13 @@ conda. Download and install [Miniconda](https://conda.io/miniconda.html), then
 run
 
 ```
+git clone --recurse-submodules https://github.com/flatsurf/cppyythonizations.git
+cd cppyythonizations
 conda create -n cppyythonizations-build
 conda env update -n cppyythonizations-build -f environment.yml
 conda activate cppyythonizations-build
-git clone --recurse-submodules https://github.com/flatsurf/cppyythonizations.git
 ./bootstrap
-./configure --prefix="$CONDA_PREFIX"
+./configure
 make
 ```
 
@@ -72,7 +78,7 @@ git clone --recurse-submodules https://github.com/flatsurf/cppyythonizations.git
 cd cppyythonizations
 conda activate root
 conda config --add channels conda-forge
-conda config --add channels flatsurf # if you want to pull in the latest version of dependencies
+conda config --add channels flatsurf
 conda install conda-build conda-forge-ci-setup=2
 export FEEDSTOCK_ROOT=`pwd`
 export RECIPE_ROOT=${FEEDSTOCK_ROOT}/recipe

--- a/doc/news/pypi.rst
+++ b/doc/news/pypi.rst
@@ -1,0 +1,3 @@
+**Added:**
+
+* add package to PyPI so we can `pip install cppyythonizations`

--- a/src/MANIFEST.in.in
+++ b/src/MANIFEST.in.in
@@ -1,3 +1,5 @@
 graft @srcdir@/cppyythonizations/include
 include @srcdir@/cppyythonizations/pickling/cereal.hpp
-include @srcdir@/../COPYING
+graft @srcdir@/../COPYING
+global-exclude __pycache__
+global-exclude *.py[cod]

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,4 +18,4 @@ CLEANFILES = setup.py MANIFEST.in
 $(builddir)/setup.py: $(srcdir)/setup.py.in Makefile
 	sed -e 's,[@]abs_top_srcdir[@],$(abs_top_srcdir),g' -e 's,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g' < $< > $@
 $(builddir)/MANIFEST.in: $(srcdir)/MANIFEST.in.in Makefile
-	sed -e 's,[@]srcdir[@],$(srcdir),g' < $< > $@
+	sed -e 's,[@]srcdir[@],'`realpath --relative-to=$(builddir) $(srcdir)`',g' < $< > $@

--- a/src/setup.py.in
+++ b/src/setup.py.in
@@ -12,13 +12,16 @@ class vpath_egg_info(egg_info):
 
 setup(
     name = 'cppyythonizations',
+    author = 'Julian Rüth',
+    author_email = 'julian.rueth@fsfe.org',
     version = '@PACKAGE_VERSION@',
+    url = 'https://github.com/flatsurf/cppyythonizations',
     packages = ['cppyythonizations', 'cppyythonizations.pickling', 'cppyythonizations.util', 'cppyythonizations.operators', 'cppyythonizations.vector', 'cppyythonizations.tuple', 'cppyythonizations.printing'],
     license = 'MIT',
     install_requires=[
         'cppyy'
     ],
-    long_description = open('@abs_top_srcdir@/README.md').read(),
+    long_description = "A collection of Pythonizations for cppyy",
     include_package_data=True,
     cmdclass={ 'egg_info': vpath_egg_info },
     package_dir={ "": os.path.relpath('@abs_top_srcdir@/src/') },

--- a/tools/rever/dist.xsh
+++ b/tools/rever/dist.xsh
@@ -22,47 +22,25 @@
 # SOFTWARE.
 # ********************************************************************
 
-import sys
+from rever.activity import Activity
 
-try:
-  input("Are you sure you are on the master branch which is identical to origin/master? [ENTER]")
-except KeyboardInterrupt:
-  sys.exit(1)
+class AutotoolsDist(Activity):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.name = "dist"
+        self.desc = "Creates a source tarball with make dist"
+        self.requires = {"commands": {"make": "make"}}
 
-sys.path.insert(0, 'tools/rever')
-
-import dist
-import autopypi
-
-$PROJECT = 'cppyythonizations'
-
-$ACTIVITIES = [
-    'version_bump',
-    'changelog',
-    'dist',
-    'autopypi',
-    'tag',
-    'push_tag',
-    'ghrelease',
-]
-
-$VERSION_BUMP_PATTERNS = [
-    ('configure.ac', r'AC_INIT', r'AC_INIT([cppyythonizations], [$VERSION], [julian.rueth@fsfe.org])'),
-    ('recipe/meta.yaml', r"\{% set version =", r"{% set version = '$VERSION' %}"),
-    ('recipe/meta.yaml', r"\{% set build_number =", r"{% set build_number = '0' %}"),
-]
-
-$CHANGELOG_FILENAME = 'ChangeLog'
-$CHANGELOG_TEMPLATE = 'TEMPLATE.rst'
-$CHANGELOG_NEWS = 'doc/news'
-$PUSH_TAG_REMOTE = 'git@github.com:flatsurf/cppyythonizations.git'
-
-$GITHUB_ORG = 'flatsurf'
-$GITHUB_REPO = 'cppyythonizations'
-
-$PYPI_BUILD_COMMANDS = []
-$PYPI_NAME = "cppyythonizations"
-
-$AUTOPYPI_ROOT = "src"
-
-$GHRELEASE_ASSETS = ['cppyythonizations-' + $VERSION + '.tar.gz']
+    def __call__(self):
+        from tempfile import TemporaryDirectory
+        from xonsh.dirstack import DIRSTACK
+        with TemporaryDirectory() as tmp:
+            ./bootstrap
+            pushd @(tmp)
+            @(DIRSTACK[-1])/configure
+            make dist
+            mv *.tar.gz @(DIRSTACK[-1])
+            popd
+        return True
+    
+$DAG['dist'] = AutotoolsDist()


### PR DESCRIPTION
because of our autoconfiscated setup, we only distribute a wheel on
PyPI. This is not ideal but we would need another setup.py for
in-tree builds to create a proper sdist.